### PR TITLE
django.conf.urls.patterns will be removed in Django 1.10

### DIFF
--- a/identeco/urls.py
+++ b/identeco/urls.py
@@ -1,13 +1,12 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from identeco import views
 
 
-urlpatterns = patterns(
-    "",
+urlpatterns = [
     url(r"^xrds\.xml$", views.XRDS.as_view(), name="identeco_xrds"),
     url(r"^endpoint/$", views.Endpoint.as_view(), name="identeco_endpoint"),
     url(r"^decide/$", views.DecideTrust.as_view(), name="identeco_decide_trust"),
     url(r"^(?P<username>[^/]+)/$", views.Identity.as_view(), name="identeco_identity"),
     url(r"^(?P<username>[^/]+)/xrds\.xml$", views.XRDS.as_view(identity=True), name="identeco_identity_xrds"),
-)
+]


### PR DESCRIPTION
This PR fixes a `RemovedInDjango110Warning` about `django.conf.urls.patterns` being removed in Django 1.10. URLs should now be specified as a plain list of `url()` instances.
